### PR TITLE
Fix path shortening to handle Unicode correctly

### DIFF
--- a/converter/misc.go
+++ b/converter/misc.go
@@ -44,8 +44,8 @@ func size(file string) (n int64) {
 }
 
 func shorten(path string) string {
-	if len(path) > 50 {
-		return path[:25] + "..." + path[len(path)-25:]
+	if runes := []rune(path); len(runes) > 50 {
+		return string(runes[:25]) + " ... " + string(runes[len(runes)-25:])
 	}
 	return path
 }


### PR DESCRIPTION
Updated the shorten function to use rune slicing instead of byte slicing, ensuring proper handling of Unicode paths longer than 50 characters.